### PR TITLE
Optimisations

### DIFF
--- a/core/class/scan_ip.shell.php
+++ b/core/class/scan_ip.shell.php
@@ -28,7 +28,7 @@ class scan_ip_shell extends eqLogic {
         
         $retry = config::byKey('add_retry_scan', 'scan_ip', 3);
         
-        exec('sudo arp-scan -r ' . $retry .  ' --interface=' . $_subReseau . ' --localnet --ouifile=' . scan_ip::$_file_oui,$output);
+        exec('sudo arp-scan --nodns --retry=' . $retry .  ' --interval=2 --timeout=300 --interface=' . $_subReseau . ' --localnet --ouifile=' . scan_ip::$_file_oui, $output);        
         
         foreach ($output as $scanLine) {
             if (preg_match(scan_ip_tools::getRegex("ip_v4"), $scanLine)) {     


### PR DESCRIPTION
### bridges_getElements
- Chargement de tous les plugins en une requete (plugin::listPlugin())
- mise en cache afin de ne pas le répéter autant de fois qu'il y a d'équipements

### arp-scan
- ajout de --nodns : pas besoin de résolution de dns dans le cadre de ce plugin
- --timeout=300 : on reduit le temps d'attente des réponses (par défaut 500ms) : une requete arp est sensé répondre un quelques millisecondes
- --interval=2 : on ajoute un petit temps entre l'envoie des paquets arp, afin de ne pas surcharger la file d'attente et ne pas créer de faux négatifs sur de vieux équipements