### PR TITLE
Optimisation

### DIFF
--- a/core/class/scan_ip.cmd.php
+++ b/core/class/scan_ip.cmd.php
@@ -33,9 +33,6 @@ class scan_ip_cmd extends eqLogic {
                 scan_ip_widget_alerte::cmdRefreshWidgetAlerte($_eqlogic, $mapping);
                 break;
         }
-        
-        $_eqlogic->toHtml('dashboard');
-        $_eqlogic->refreshWidget();
     }
     
 }

--- a/core/class/scan_ip.profiler.class.php
+++ b/core/class/scan_ip.profiler.class.php
@@ -1,0 +1,87 @@
+<?php
+  
+class Profiler {
+    private static $stack = [];
+    private static $depth = 0;
+  
+    /**
+     * à appeller en début de méthode pour laquelle on veut mesurer le temps d'exécution.
+     * Il faut utiliser le même nom que celui passé à stop()
+     * Exemple : Profiler::start(__METHOD__);
+     * */
+    public static function start($name) {
+        $indent = str_repeat("  ", self::$depth);
+        log::add('scan_ip', 'debug', "[Profilage] " . $indent . "START : " . $name);
+        
+        self::$stack[] = [
+            'name' => $name,
+            'start' => microtime(true),
+            'children' => [] 
+        ];
+
+        self::$depth++;
+    }
+
+    /**
+     * à appeller en fin de méthode pour laquelle on veut mesurer le temps d'exécution.
+     * Optionnel : $showSummary = true pour afficher un résumé des sous-appels effectués par la méthode.
+     * Il faut utiliser le même nom que celui passé à start()
+     * Exemple : Profiler::stop(__METHOD__);
+     * */
+    public static function stop($name, $showSummary = false) {
+        $endTime = microtime(true);
+        $current = array_pop(self::$stack);
+        
+        if (!$current || $current['name'] !== $name) {
+            return null;
+        }
+
+        self::$depth--;
+        if (self::$depth < 0) self::$depth = 0;
+        
+        $duration = $endTime - $current['start'];
+        $indent = str_repeat("  ", self::$depth);
+        
+        log::add('scan_ip', 'debug', "[Profilage] " . $indent . "STOP  : $name : " . round($duration, 4) . "s");
+
+        // GESTION DU RÉSUMÉ GLOBAL
+        if ($showSummary && !empty($current['children'])) {
+            $summaryStr = "[Profilage Résumé Global $name] :";
+            // Tri par temps décroissant pour voir le plus lourd en premier
+            uasort($current['children'], function($a, $b) {
+                return $b['time'] <=> $a['time'];
+            });
+            
+            foreach ($current['children'] as $childName => $stats) {
+                $summaryStr .= "\n[Profilage Résumé Global $name]   -> " . $childName . " | Appel(s): " . $stats['count'] . " | Total: " . round($stats['time'], 4) . "s";
+            }
+            log::add('scan_ip', 'debug', $summaryStr);
+        }
+
+        // TRANSMISSION RÉCURSIVE AU PARENT
+        $stackSize = count(self::$stack);
+        if ($stackSize > 0) {
+            $parentIdx = $stackSize - 1;
+            
+            // 1. On transmet l'appel actuel au parent
+            self::updateStats(self::$stack[$parentIdx]['children'], $name, $duration);
+            
+            // 2. NOUVEAUTÉ : On transmet aussi tous les sous-appels collectés par l'appel actuel au parent
+            foreach ($current['children'] as $childName => $childStats) {
+                self::updateStats(self::$stack[$parentIdx]['children'], $childName, $childStats['time'], $childStats['count']);
+            }
+        }
+
+        return $duration;
+    }
+
+    // Petite fonction utilitaire pour centraliser la mise à jour des stats
+    private static function updateStats(&$target, $name, $time, $count = 1) {
+        if (!isset($target[$name])) {
+            $target[$name] = ['count' => 0, 'time' => 0];
+        }
+        $target[$name]['count'] += $count;
+        $target[$name]['time'] += $time;
+    }
+}
+

--- a/core/class/scan_ip.require_once.php
+++ b/core/class/scan_ip.require_once.php
@@ -14,4 +14,5 @@
     require_once __DIR__ . "/../../../../plugins/scan_ip/core/class/scan_ip.api_mac_vendor.php";
     require_once __DIR__ . "/../../../../plugins/scan_ip/core/class/scan_ip.maj.php";
     require_once __DIR__ . "/../../../../plugins/scan_ip/core/class/scan_ip.developpement.php";
+    require_once __DIR__ . "/../../../../plugins/scan_ip/core/class/scan_ip.profiler.php";
 ?>

--- a/core/class/scan_ip.widget_normal.php
+++ b/core/class/scan_ip.widget_normal.php
@@ -11,6 +11,7 @@ require_once __DIR__ . "/../../../../plugins/scan_ip/core/class/scan_ip.require_
 class scan_ip_widget_normal extends eqLogic {
     
     public static function cmdRefreshWidgetNormal($_eqlogic, $_mapping = NULL){
+        // 1. Récupération des données de l'appareil
         $device = scan_ip_json::searchByMac($_eqlogic->getConfiguration("mac_id"), $_mapping);
         $offline_time = $_eqlogic->getConfiguration("offline_time", scan_ip::$_defaut_offline_time);
         $isOnline = (!empty($device["time"]) && scan_ip_tools::isOffline($offline_time, $device["time"]) == 0);
@@ -42,14 +43,13 @@ class scan_ip_widget_normal extends eqLogic {
             }
         }
 
-        // 4. Gestion des dates (CIBLE DE L'OPTIMISATION)
+        // 4. Gestion des dates uniquement si l'appareil est Online et que la date de dernière communication est disponible
         if ($isOnline && !empty($device["time"])) {
             $oldIp = $_eqlogic->getConfiguration('last_ip_v4');
 
             // CONDITION : On ne met à jour la date que si :
             // - L'appareil vient de passer Online ($hasChangedStatus)
             // - OU l'IP a changé ($oldIp != $device["ip_v4"])
-            // - OU on est à une minute ronde (ex: :00) pour garder une trace en base
             if ($hasChangedStatus || $oldIp != $device["ip_v4"]) {
                 if (isset($cmdCache['update_time'])) {
                     $cmdCache['update_time']->event($device["time"]);

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -102,6 +102,8 @@ $paquetBridges = ceil(count(scan_ip_bridges::getJsonBridges())/3);
             </label>
             <div class="col-lg-5">
                 <select class="configKey form-control" data-l1key="add_retry_scan">
+                    <option value="1">{{1 tentatives}}</option>
+                    <option value="2">{{2 tentatives}}</option>
                     <option value="3">{{3 tentatives (à defaut)}}</option>
                     <option value="4">{{4 tentatives}}</option>
                     <option value="5">{{5 tentatives}}</option>


### PR DESCRIPTION
- update_date et l’update_time ne sont plus mis à jour qu’en cas de modification d’une des commandes de équipement (manipulation des dates très coûteuse)
- collectDate n’est plus mis à jour que si l’équipement est online, ce qui permet d’avoie une date de dernière communication de l’équipement cohérente avec la dernière vue sur le réseau et de faire fonctionner la fonction d’alerte en cas de non communication native de jeedom.
- Possibilité pour l’utilisateur de choisir un retry à 1 ou 2, ce qui doit marcher sur un bon réseau et fait gagner un peu de temps sur l’arp-scan.